### PR TITLE
Change 'Name' prompt to ask for full name

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
           <form class="details-form" style="display: none">
             <div>
               <label>
-                Name (ex: John P. Smith)<br>
+                Full name (first, middle, last; ex: John P. Smith)<br>
                 <input name="name" type="text" placeholder="Name" required value="<%- name %>">
               </label>
             </div>
@@ -108,7 +108,7 @@
             </div>
 
             <p><b>Is <%- name %> considered</b></p>
-            
+
             <ul class="review-list">
               <li class="styled-list">
                 <div class="modal">
@@ -213,7 +213,7 @@
           <div class="details-form" style="display: none">
             <div>
               <label>
-                Name (ex: John P. Smith)<br>
+                Full name (first, middle, last; ex: John P. Smith)<br>
                 <input name="name" type="text" placeholder="Name" value="<%- person.name %>">
               </label>
             </div>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
           <form class="details-form" style="display: none">
             <div>
               <label>
-                Full name (first, middle, last; ex: John P. Smith)<br>
+                Full name (first, middle, last; ex: Pat J. Smith)<br>
                 <input name="name" type="text" placeholder="Name" required value="<%- name %>">
               </label>
             </div>
@@ -213,7 +213,7 @@
           <div class="details-form" style="display: none">
             <div>
               <label>
-                Full name (first, middle, last; ex: John P. Smith)<br>
+                Full name (first, middle, last; ex: Pat J. Smith)<br>
                 <input name="name" type="text" placeholder="Name" value="<%- person.name %>">
               </label>
             </div>


### PR DESCRIPTION
Modifies the "Name" label for kids and adults to "Full name (first, middle, last; ex: John P. Smith):"

It was "Name (ex. John P. Smith):"

Adding the "Full name" and "first, middle last" will guide users to enter the full name for people.

Closes #84